### PR TITLE
Feat/move click event listener to tag conntainer

### DIFF
--- a/modules/components/ng2-material-dropdown/components/menu/ng2-dropdown-menu.ts
+++ b/modules/components/ng2-material-dropdown/components/menu/ng2-dropdown-menu.ts
@@ -197,8 +197,8 @@ export class Ng2DropdownMenu {
 
         const top = (this.appendToBody ? vRect.top : 0) + rect.top;
         const left = (this.appendToBody ? vRect.left : 0) + rect.left;
-        const menuHeight = this.getMenuElement().clientHeight;
-        const menuWidth = this.getMenuElement().clientWidth;
+        const menuHeight = (this.getMenuElement() as HTMLElement).offsetHeight;
+        const menuWidth = (this.getMenuElement() as HTMLElement).offsetWidth;
 
         let topPx;
         let leftPx;

--- a/modules/components/tag-input/tag-input.template.html
+++ b/modules/components/tag-input/tag-input.template.html
@@ -16,7 +16,8 @@
      [class.ng2-tag-input--focused]="isInputFocused()">
 
     <!-- TAGS -->
-    <div class="ng2-tags-container">
+    <div class="ng2-tags-container"
+        (click)="dropdown ? disable || dropdown.show() : undefined">
         <tag *ngFor="let item of items; let i = index; trackBy: trackBy"
 
              (onSelect)="selectItem(item)"
@@ -31,7 +32,7 @@
              (dragenter)="dragZone ? onDragOver($event) : undefined"
              (dragover)="dragZone ? onDragOver($event, i) : undefined"
              (dragleave)="dragZone ? dragProvider.onDragEnd() : undefined"
-             
+
              [canAddTag]="isTagValid"
              [attr.tabindex]="0"
              [disabled]="disable"
@@ -50,7 +51,6 @@
         <tag-input-form
             (onSubmit)="onAddingRequested(false, formValue)"
             (onBlur)="blur()"
-            (click)="dropdown ? disable || dropdown.show() : undefined"
             (onKeydown)="fireEvents('keydown', $event)"
             (onKeyup)="fireEvents('keyup', $event)"
 


### PR DESCRIPTION
I've made some modifications:
- Fix the position of `Ng2DropdownMenu` when scrollbar is visible
- Move the click event listener from `TagInputForm` to `ng2-tag-container`. Now any click within the container will show the dropdown.

Please review and merge.