### PR TITLE
Dev/refine dropdown calc logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 
+## 1.7.6 - 2018-06-25
+- re-calc menu pos when items count change
+- tag-input-dropdown now doesn't animate width/height when show/hide
+
+## 1.7.5 - 2018-06-21
+- Update dropdown's position calculation logic. Ng2Dropdown now handle this job in the more effectively way. tag-input now don't have always to listen to scroll event as it should be (there is use-case that It does not own a dropdown)
+
+- When showDropdownIfEmpty= true Dropdown now got shown when user click on tag-input element instead of user have to clicking exactly on the the html input element
+
 ## 1.7.4 - 2018-06-20
 - better handle position of dropdown-menu (don't cover the input)
 

--- a/modules/components/dropdown/tag-input-dropdown.component.ts
+++ b/modules/components/dropdown/tag-input-dropdown.component.ts
@@ -3,18 +3,18 @@ import {
     ContentChildren,
     EventEmitter,
     forwardRef,
-    HostListener,
     Injector,
     Input,
     QueryList,
     TemplateRef,
     Type,
     ViewChild,
+    ElementRef
 } from '@angular/core';
 
 // rx
 import { Observable } from 'rxjs/Observable';
-import { map, filter, first, debounceTime } from 'rxjs/operators';
+import { filter, first, debounceTime } from 'rxjs/operators';
 
 import { Ng2Dropdown, Ng2MenuItem } from '../ng2-material-dropdown/ng2-dropdown.module';
 import { OptionsProvider } from '../../core/providers/options-provider';
@@ -144,6 +144,11 @@ export class TagInputDropdown {
         });
     }
 
+    /**
+   * @name anchor: ElementRef
+   */
+    @Input() public anchor: ElementRef;
+
     constructor(private readonly injector: Injector) {}
 
     /**
@@ -159,7 +164,7 @@ export class TagInputDropdown {
         const KEEP_OPEN = this.keepOpen;
 
         this.tagInput
-            .onTextChange
+        .onTextChange
             .asObservable()
             .pipe(
                 debounceTime(DEBOUNCE_TIME),
@@ -174,14 +179,6 @@ export class TagInputDropdown {
             .subscribe(this.show);
     }
 
-    /**
-     * @name updatePosition
-     */
-    public updatePosition(): void {
-        const position = this.tagInput.inputForm.getElementPosition();
-
-        this.dropdown.menu.updatePosition(position);
-    }
 
     /**
      * @name isVisible
@@ -226,7 +223,6 @@ export class TagInputDropdown {
         const maxItemsReached = this.tagInput.items.length === this.tagInput.maxItems;
         const value = this.getFormValue();
         const hasMinimumText = value.trim().length >= this.minimumTextLength;
-        const position = this.calculatePosition();
         const items = this.getMatchingItems(value);
         const hasItems = items.length > 0;
         const isHidden = this.isVisible === false;
@@ -248,7 +244,7 @@ export class TagInputDropdown {
         this.setItems(items);
 
         if (shouldShow) {
-            this.dropdown.show(position);
+            this.dropdown.show(this.anchor);
         } else if (shouldHide) {
             this.hide();
         }
@@ -263,37 +259,10 @@ export class TagInputDropdown {
     }
 
     /**
-     * @name scrollListener
-     */
-    @HostListener('window:scroll')
-    public scrollListener(): void {
-        if (!this.isVisible) {
-            return;
-        }
-
-        this.updatePosition();
-    }
-
-    /**
-     * @name onWindowBlur
-     */
-    @HostListener('window:blur')
-    public onWindowBlur(): void {
-        this.dropdown.hide();
-    }
-
-    /**
      * @name getFormValue
      */
     private getFormValue(): string {
         return this.tagInput.formValue.trim();
-    }
-
-    /**
-     * @name calculatePosition
-     */
-    private calculatePosition(): ClientRect {
-        return this.tagInput.inputForm.getElementPosition();
     }
 
     /**
@@ -387,7 +356,7 @@ export class TagInputDropdown {
             this.setItems(this.getMatchingItems(text));
 
             if (this.items.length) {
-                this.dropdown.show(this.calculatePosition());
+                this.dropdown.show(this.anchor);
             } else if (!this.showDropdownIfEmpty && this.isVisible) {
                 this.dropdown.hide();
             } else if (!this.showDropdownIfEmpty) {

--- a/modules/components/dropdown/tag-input-dropdown.component.ts
+++ b/modules/components/dropdown/tag-input-dropdown.component.ts
@@ -215,6 +215,8 @@ export class TagInputDropdown {
         return this.dropdown.menu.state;
     }
 
+    @Input() public hideOnBlur = true;
+
     /**
      *
      * @name show

--- a/modules/components/dropdown/tag-input-dropdown.template.html
+++ b/modules/components/dropdown/tag-input-dropdown.template.html
@@ -1,4 +1,4 @@
-<ng2-dropdown>
+<ng2-dropdown [hideOnBlur]="hideOnBlur">
     <ng2-dropdown-menu [focusFirstElement]="focusFirstElement"
                        [appendToBody]="appendToBody"
                        [offset]="offset">

--- a/modules/components/ng2-material-dropdown/components/menu/ng2-dropdown-menu.ts
+++ b/modules/components/ng2-material-dropdown/components/menu/ng2-dropdown-menu.ts
@@ -102,6 +102,7 @@ export class Ng2DropdownMenu {
      */
     @ContentChildren(Ng2MenuItem) public items: QueryList<Ng2MenuItem>;
 
+    public postionUpdated = false;
 
     private listeners = {
         arrowHandler: noop,
@@ -137,6 +138,8 @@ export class Ng2DropdownMenu {
      * @desc hides menu
      */
     public hide(): void {
+        this.postionUpdated = false;
+
         this.state.menuState.isVisible = false;
         this.visibilityChange.emit(this.state.menuState.isVisible);
 
@@ -154,6 +157,8 @@ export class Ng2DropdownMenu {
      * @param position {ClientRect}
      */
     public updatePosition(position: ClientRect, width = 0): void {
+        // the menu should visible only after it's position  has been updated
+        this.postionUpdated  = true;
 
         const element = this.getMenuElement();
 
@@ -188,7 +193,7 @@ export class Ng2DropdownMenu {
      * @name getMenuElement
      * @returns {Element}
      */
-    private getMenuElement(): Element {
+    public getMenuElement(): HTMLElement {
         return this.element.nativeElement.children[0];
     }
 
@@ -209,11 +214,12 @@ export class Ng2DropdownMenu {
 
         const vRect = this.viewportRuler.getViewportRect();
 
+        const menu = (this.getMenuElement() as HTMLElement);
+
         const top = (this.appendToBody ? vRect.top : 0) + rect.top;
         const left = (this.appendToBody ? vRect.left : 0) + rect.left;
-        const menuHeight = (this.getMenuElement() as HTMLElement).offsetHeight;
-        const menuWidth =
-         anchor ? anchor.getBoundingClientRect().width : (this.getMenuElement() as HTMLElement).offsetWidth;
+        const menuHeight = menu.offsetHeight;
+        const menuWidth = anchor ? anchor.getBoundingClientRect().width : menu.offsetWidth;
 
         let topPx;
         let leftPx;

--- a/modules/components/ng2-material-dropdown/components/menu/ng2-dropdown-menu.ts
+++ b/modules/components/ng2-material-dropdown/components/menu/ng2-dropdown-menu.ts
@@ -10,7 +10,9 @@ import {
     transition,
     animate,
     keyframes,
-    state
+    state,
+    EventEmitter,
+    Output
 } from '@angular/core';
 
 import { ACTIONS, arrowKeysHandler } from './actions';
@@ -52,6 +54,7 @@ const noop: Function = () => {};
     ]
 })
 export class Ng2DropdownMenu {
+    @Output() public visibilityChange: EventEmitter<boolean> = new EventEmitter<boolean>();
     /**
      * @name width
      * @type {number} [2, 4, 6]
@@ -117,6 +120,7 @@ export class Ng2DropdownMenu {
     public show(width = 0): void {
         // update state
         this.state.menuState.isVisible = true;
+        this.visibilityChange.emit(this.state.menuState.isVisible);
 
         const element = this.getMenuElement();
 
@@ -134,6 +138,7 @@ export class Ng2DropdownMenu {
      */
     public hide(): void {
         this.state.menuState.isVisible = false;
+        this.visibilityChange.emit(this.state.menuState.isVisible);
 
         // reset selected item state
         this.state.dropdownState.unselect();
@@ -200,7 +205,7 @@ export class Ng2DropdownMenu {
      * @param rect
      * @returns {{top: string, left: string}}
      */
-    public calcPositionOffset(rect, anchor: HTMLElement): { top: string, left: string } {
+    public calcPositionOffset(rect, anchor: HTMLElement): { top: string, left: string, width: string } {
 
         const vRect = this.viewportRuler.getViewportRect();
 
@@ -239,7 +244,8 @@ export class Ng2DropdownMenu {
 
         return {
             top: topPx,
-            left: leftPx
+            left: leftPx,
+            width: `${menuWidth}px`
         };
     }
 

--- a/modules/components/ng2-material-dropdown/components/menu/ng2-dropdown-menu.ts
+++ b/modules/components/ng2-material-dropdown/components/menu/ng2-dropdown-menu.ts
@@ -28,23 +28,11 @@ const noop: Function = () => {};
     animations: [
         trigger('fade', [
             state('visible', style(
-                {display: 'block', height: '*', width: '*'}
+                {display: 'block'}
             )),
             state('hidden', style(
-                {display: 'none', overflow: 'hidden', height: 0, width: 0}
-            )),
-            transition('hidden => visible', [
-                animate('250ms ease-in', keyframes([
-                    style({opacity: 0, offset: 0}),
-                    style({opacity: 1, offset: 1, height: '*', width: '*'}),
-                ]))
-            ]),
-            transition('visible => hidden', [
-                animate('350ms ease-out', keyframes([
-                    style({opacity: 1, offset: 0}),
-                    style({opacity: 0, offset: 1, width: '0', height: '0'}),
-                ]))
-            ])
+                {display: 'none', overflow: 'hidden'}
+            ))
         ]),
         trigger('opacity', [
             transition('hidden => visible', [

--- a/modules/components/ng2-material-dropdown/components/menu/ng2-dropdown-menu.ts
+++ b/modules/components/ng2-material-dropdown/components/menu/ng2-dropdown-menu.ts
@@ -19,6 +19,8 @@ import { Ng2MenuItem } from '../menu-item/ng2-menu-item';
 import { DropdownStateService } from '../../services/dropdown-state.service';
 import { ViewportRuler } from '../../services/viewport-ruler';
 
+const noop: Function = () => {};
+
 @Component({
     selector: 'ng2-dropdown-menu',
     styleUrls: [ './style.scss' ],
@@ -66,14 +68,14 @@ export class Ng2DropdownMenu {
      * @name width
      * @type {number} [2, 4, 6]
      */
-    @Input() public width: number = 4;
+    @Input() public width = 4;
 
     /**
      * @description if set to true, the first element of the dropdown will be automatically focused
      * @name focusFirstElement
      * @type {boolean}
      */
-    @Input() public focusFirstElement: boolean = true;
+    @Input() public focusFirstElement = true;
 
     /**
      * @description sets dropdown offset from the button
@@ -86,7 +88,7 @@ export class Ng2DropdownMenu {
             return 0;
         }
         const v = this.offset.split(' ', 2).shift();
-        return parseInt(v.replace('px', ''), 10);
+        return parseInt(v!.replace('px', ''), 10);
     }
 
     public get offsetY(): number {
@@ -94,14 +96,14 @@ export class Ng2DropdownMenu {
             return 0;
         }
         const v = this.offset.split(' ', 2).pop();
-        return parseInt(v.replace('px', ''), 10);
+        return parseInt(v!.replace('px', ''), 10);
     }
 
     /**
      * @name appendToBody
      * @type {boolean}
      */
-    @Input() public appendToBody: boolean = true;
+    @Input() public appendToBody = true;
 
     /**
      * @name items
@@ -109,11 +111,10 @@ export class Ng2DropdownMenu {
      */
     @ContentChildren(Ng2MenuItem) public items: QueryList<Ng2MenuItem>;
 
-    private position: ClientRect;
 
     private listeners = {
-        arrowHandler: undefined,
-        handleKeypress: undefined
+        arrowHandler: noop,
+        handleKeypress: noop
     };
 
     constructor(public state: DropdownStateService,
@@ -125,16 +126,18 @@ export class Ng2DropdownMenu {
      * @name show
      * @shows menu and selects first item
      */
-    public show(): void {
-        const dc = typeof document !== 'undefined' ? document : undefined;
-        const wd = typeof window !== 'undefined' ? window : undefined;
-
+    public show(width = 0): void {
         // update state
         this.state.menuState.isVisible = true;
 
+        const element = this.getMenuElement();
+
+        if (width > 0) {
+            this.renderer.setElementStyle(element, 'width', `${width}px`);
+        }
         // setting handlers
-        this.listeners.handleKeypress = this.renderer.listen(dc.body, 'keydown', this.handleKeypress.bind(this));
-        this.listeners.arrowHandler = this.renderer.listen(wd, 'keydown', arrowKeysHandler);
+        this.listeners.handleKeypress = this.renderer.listen(document!.body, 'keydown', this.handleKeypress.bind(this));
+        this.listeners.arrowHandler = this.renderer.listen(window, 'keydown', arrowKeysHandler);
     }
 
     /**
@@ -148,8 +151,8 @@ export class Ng2DropdownMenu {
         this.state.dropdownState.unselect();
 
         // call function to unlisten
-        this.listeners.arrowHandler ? this.listeners.arrowHandler() : undefined;
-        this.listeners.handleKeypress ? this.listeners.handleKeypress() : undefined;
+        this.listeners.arrowHandler();
+        this.listeners.handleKeypress();
     }
 
     /**
@@ -157,9 +160,18 @@ export class Ng2DropdownMenu {
      * @desc updates the menu position every time it is toggled
      * @param position {ClientRect}
      */
-    public updatePosition(position: ClientRect): void {
-        this.position = position;
-        this.ngDoCheck();
+    public updatePosition(position: ClientRect, width = 0): void {
+
+        const element = this.getMenuElement();
+
+        if (position) {
+            this.renderer.setElementStyle(element, 'top', position.top + '');
+            this.renderer.setElementStyle(element, 'left', position.left + '');
+        }
+
+        if (width > 0) {
+            this.renderer.setElementStyle(element, 'width', `${width}px`);
+        }
     }
 
     /**
@@ -188,26 +200,39 @@ export class Ng2DropdownMenu {
     }
 
     /**
+     * @name getBackdropElement
+     * @returns {Element}
+     */
+    public getBackdropElement(): Element {
+        return this.element.nativeElement.children[1];
+    }
+
+    /**
      * @name calcPositionOffset
      * @param rect
      * @returns {{top: string, left: string}}
      */
-    private calcPositionOffset(rect): { top: string, left: string } {
+    public calcPositionOffset(rect, anchor: HTMLElement): { top: string, left: string } {
+
         const vRect = this.viewportRuler.getViewportRect();
 
         const top = (this.appendToBody ? vRect.top : 0) + rect.top;
         const left = (this.appendToBody ? vRect.left : 0) + rect.left;
         const menuHeight = this.getMenuElement().clientHeight;
-        const menuWidth = this.getMenuElement().clientWidth;
+        const menuWidth = anchor ? anchor.getBoundingClientRect().width : this.getMenuElement().clientWidth;
 
         let topPx;
         let leftPx;
+
 
         // Available space at the top and bottom
         const topAvailable = rect.top - this.offsetY;
         const bottomAvailable = vRect.height - (rect.bottom + this.offsetY);
 
-        if (rect.bottom + this.offsetY + menuHeight > vRect.height && bottomAvailable < topAvailable) {
+        if (
+            rect.bottom + this.offsetY + menuHeight > vRect.height &&
+            bottomAvailable < topAvailable
+        ) {
             // NOTE: 上に表示
             topPx = `${top - menuHeight - this.offsetY}px`;
         } else {
@@ -230,23 +255,14 @@ export class Ng2DropdownMenu {
     }
 
     public ngOnInit() {
-        const dc = typeof document !== 'undefined' ? document : undefined;
         if (this.appendToBody) {
             // append menu element to the body
-            dc.body.appendChild(this.element.nativeElement);
+            document!.body!.appendChild(this.element.nativeElement);
         }
     }
 
     public ngDoCheck() {
-        if (this.state.menuState.isVisible && this.position) {
-            const element = this.getMenuElement();
-            const position = this.calcPositionOffset(this.position);
-
-            if (position) {
-                this.renderer.setElementStyle(element, 'top', position.top);
-                this.renderer.setElementStyle(element, 'left', position.left);
-            }
-
+        if (this.state.menuState.isVisible) {
             // select first item unless user disabled this option
             if (this.focusFirstElement &&
                 this.items.first &&

--- a/modules/components/ng2-material-dropdown/components/menu/template.html
+++ b/modules/components/ng2-material-dropdown/components/menu/template.html
@@ -10,4 +10,4 @@
 </div>
 
 <!-- BACKDROP -->
-<div class="ng2-dropdown-backdrop" *ngIf="state.menuState.isVisible" (click)="hide()"></div>
+<div class="ng2-dropdown-backdrop" *ngIf="state.menuState.isVisible"></div>

--- a/modules/components/ng2-material-dropdown/components/menu/template.html
+++ b/modules/components/ng2-material-dropdown/components/menu/template.html
@@ -1,5 +1,5 @@
 <!-- MENU -->
-<div class='ng2-dropdown-menu ng2-dropdown-menu---width--{{ width }}'
+<div [style.visibility]="postionUpdated? 'visible' : 'hidden'" class='ng2-dropdown-menu ng2-dropdown-menu---width--{{ width }}'
      [class.ng2-dropdown-menu--inside-element]="!appendToBody"
      [class.ng2-dropdown-menu--open]="state.menuState.isVisible"
      [@fade]="state.menuState.toString()">

--- a/modules/components/ng2-material-dropdown/services/ng2-dropdown-state.ts
+++ b/modules/components/ng2-material-dropdown/services/ng2-dropdown-state.ts
@@ -37,6 +37,6 @@ export class Ng2DropdownState {
      * @desc sets _selectedItem as undefined
      */
     public unselect(): void {
-        this._selectedItem = undefined;
+        delete this._selectedItem;
     }
 }

--- a/modules/components/tag-input/tag-input.template.html
+++ b/modules/components/tag-input/tag-input.template.html
@@ -17,7 +17,7 @@
 
     <!-- TAGS -->
     <div class="ng2-tags-container"
-        (click)="dropdown ? disable || dropdown.show(element) : undefined">
+        (click)="dropdown ? disable || dropdown.show() : undefined">
         <tag *ngFor="let item of items; let i = index; trackBy: trackBy"
 
              (onSelect)="selectItem(item)"

--- a/modules/components/tag-input/tag-input.template.html
+++ b/modules/components/tag-input/tag-input.template.html
@@ -31,7 +31,7 @@
              (dragenter)="dragZone ? onDragOver($event) : undefined"
              (dragover)="dragZone ? onDragOver($event, i) : undefined"
              (dragleave)="dragZone ? dragProvider.onDragEnd() : undefined"
-             
+
              [canAddTag]="isTagValid"
              [attr.tabindex]="0"
              [disabled]="disable"
@@ -50,7 +50,7 @@
         <tag-input-form
             (onSubmit)="onAddingRequested(false, formValue)"
             (onBlur)="blur()"
-            (click)="dropdown ? disable || dropdown.show() : undefined"
+            (click)="dropdown ? disable || dropdown.show(element) : undefined"
             (onKeydown)="fireEvents('keydown', $event)"
             (onKeyup)="fireEvents('keyup', $event)"
 

--- a/modules/components/tag-input/tag-input.ts
+++ b/modules/components/tag-input/tag-input.ts
@@ -15,7 +15,9 @@ import {
     TemplateRef,
     QueryList,
     AfterViewInit,
-    Type
+    Type,
+    AfterContentInit,
+    ElementRef
 } from '@angular/core';
 
 import {
@@ -64,7 +66,7 @@ const defaults: Type<TagInputOptions> = forwardRef(() => OptionsProvider.default
     templateUrl: './tag-input.template.html',
     animations
 })
-export class TagInputComponent extends TagInputAccessor implements OnInit, AfterViewInit {
+export class TagInputComponent extends TagInputAccessor implements OnInit, AfterViewInit, AfterContentInit {
     /**
      * @name separatorKeys
      * @desc keyboard keys with which a user can separate items
@@ -373,6 +375,7 @@ export class TagInputComponent extends TagInputAccessor implements OnInit, After
     public animationMetadata: { value: string, params: object };
 
     constructor(private readonly renderer: Renderer2,
+                protected element: ElementRef,
                 public readonly dragProvider: DragProvider) {
         super();
     }
@@ -1084,5 +1087,11 @@ export class TagInputComponent extends TagInputAccessor implements OnInit, After
             value: 'in',
             params: {...this.animationDuration}
         };
+    }
+
+    ngAfterContentInit(): void {
+        if (this.dropdown) {
+            this.dropdown.anchor = this.element;
+        }
     }
 }

--- a/modules/defaults.ts
+++ b/modules/defaults.ts
@@ -100,7 +100,7 @@ export const defaults = {
         displayBy: 'display',
         identifyBy: 'value',
         appendToBody: true,
-        offset: '50 0',
+        offset: '0 0',
         focusFirstElement: false,
         showDropdownIfEmpty: false,
         minimumTextLength: 1,

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "codecov": "^2.1.0",
     "core-js": "^2.4.1",
     "css-loader": "^0.28.1",
+    "detect-passive-events": "^1.0.4",
     "es6-promise": "4.1.0",
     "es6-shim": "0.35.3",
     "extract-text-webpack-plugin": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-chips-4x",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "description": "Tag Input component for Angular",
   "scripts": {
     "release": "npm run build && npm publish dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-chips-4x",
-  "version": "1.7.4",
+  "version": "1.7.6",
   "description": "Tag Input component for Angular",
   "scripts": {
     "release": "npm run build && npm publish dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-chips-4x",
-  "version": "1.7.7",
+  "version": "1.7.8",
   "description": "Tag Input component for Angular",
   "scripts": {
     "release": "npm run build && npm publish dist",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1638,6 +1638,10 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
+detect-passive-events@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/detect-passive-events/-/detect-passive-events-1.0.4.tgz#6ed477e6e5bceb79079735dcd357789d37f9a91a"
+
 di@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/di/-/di-0.0.1.tgz#806649326ceaa7caa3306d75d985ea2748ba913c"


### PR DESCRIPTION
Big changes:

1. Update dropdown's position calculation logic. `Ng2Dropdown` now handle this job in the more effectively way. `tag-input` now don't have always to listen to scroll event as it should be (there is use-case that It does not own a dropdown)
1. When  `showDropdownIfEmpty= true` Dropdown now got shown when user click on tag-input element instead of user have to clicking exactly on the the  html input element
1. re-calc menu pos when items count change
2. tag-input-dropdown now doesn't animate width/height when show/hide