### PR TITLE
Fix/tag input hidden when max items reached on ie10

### DIFF
--- a/modules/components/tag-input/tag-input.template.html
+++ b/modules/components/tag-input/tag-input.template.html
@@ -58,6 +58,7 @@
             [disabled]="disable"
             [validators]="validators"
             [asyncValidators]="asyncValidators"
+            [hidden]="maxItemsReached"
             [style.display]="maxItemsReached ? 'none' : ''"
             [placeholder]="items.length ? placeholder : secondaryPlaceholder"
             [inputClass]="inputClass"

--- a/modules/components/tag-input/tag-input.template.html
+++ b/modules/components/tag-input/tag-input.template.html
@@ -58,7 +58,7 @@
             [disabled]="disable"
             [validators]="validators"
             [asyncValidators]="asyncValidators"
-            [hidden]="maxItemsReached"
+            [style.display]="maxItemsReached ? 'none' : ''"
             [placeholder]="items.length ? placeholder : secondaryPlaceholder"
             [inputClass]="inputClass"
             [inputId]="inputId"


### PR DESCRIPTION
This error causes by the binding in the template is supported by IE10. I've fixed it by using style binding instead. Please review and merge.