### PR TITLE
Fix/tag input dropdown filter items with undefined key and value 180730

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.13 - 2018-07-30
+- fix: supplementary fix for [v1.7.12](#1.7.12\ -\ 2018-07-26): handle items with undefined key/value that passed from form.
+- doc: add demonstration for the case items with undefined key/value passed from form.
+
 ## 1.7.12 - 2018-07-26
 - feat: handle items whose `displayBy` and/or `identifyBy` value is undefined
     - TagInputDropdown, Tag, TagInputAccessor: Update display value getter

--- a/demo/home/home.html
+++ b/demo/home/home.html
@@ -106,7 +106,7 @@
         <div>
             <h3>Tags accepting only items from an autocomplete using an observable and showing dropdown without entering text</h3>
             <tag-input [ngModel]="items" [onlyFromAutocomplete]="true">
-                <tag-input-dropdown 
+                <tag-input-dropdown
                         [showDropdownIfEmpty]="true"
                         [autocompleteObservable]="requestAutocompleteItemsFake">
                 </tag-input-dropdown>
@@ -193,6 +193,18 @@
                 <tag-input
                     [disable]="true"
                     [formControlName]="'chips'"
+                    name="items">
+                </tag-input>
+            </form>
+        </div>
+
+        <div>
+            <h3>Tags within a form group. Some items have undefined key and/or value</h3>
+            <form [formGroup]="form">
+                <tag-input
+                    [displayBy]="'name'"
+                    [identifyBy]="'id'"
+                    [formControlName]="'undefinedItems'"
                     name="items">
                 </tag-input>
             </form>

--- a/demo/home/home.ts
+++ b/demo/home/home.ts
@@ -16,7 +16,27 @@ export class Home {
 
     constructor(private http: Http) {
         this.form = new FormBuilder().group({
-            chips: [['chip'], []]
+            chips: [['chip'], []],
+            undefinedItems: [
+                [
+                    {
+                        id: undefined,
+                        name: undefined
+                    },
+                    {
+                        id: 'item with undefined display value',
+                        name: undefined
+                    },
+                    {
+                        id: undefined,
+                        name: 'item with undefined identify value'
+                    },
+                    {
+                        id: 1,
+                        name: 'This is valid item'
+                    }
+                ]
+            ]
         });
     }
 

--- a/modules/core/accessor.ts
+++ b/modules/core/accessor.ts
@@ -41,7 +41,11 @@ export class TagInputAccessor implements ControlValueAccessor {
     }
 
     public writeValue(items: any[]) {
-        this._items = items || [];
+        if (!items || items.length === 0) {
+            this._items = [];
+        } else {
+            this._items = this.filterItems(items);
+        }
     }
 
     public registerOnChange(fn: any) {
@@ -83,5 +87,40 @@ export class TagInputAccessor implements ControlValueAccessor {
      */
     protected getItemsWithout(index: number): TagModel[] {
         return this.items.filter((item, position) => position !== index);
+    }
+
+    /**
+     * Filter list of items
+     * Remove all items that
+     *  - item[this.identifyBy] is undefined
+     *  - item[this.identifyBy] AND item[this.displayBy] are undefined
+     *
+     * @private
+     * @param {any[]} items
+     * @returns
+     * @memberof TagInputAccessor
+     */
+    private filterItems(items: any[]) {
+        return items
+            .map(item => {
+                if (typeof item === 'string') {
+                    return item;
+                } else if (!item[this.identifyBy]) {
+                    // Set both indentifyBy and displayBy values
+                    // to undefined to filter later
+                    return {
+                        [this.identifyBy]: item[this.identifyBy],
+                        [this.displayBy]: item[this.identifyBy]
+                    };
+                } else {
+                    return item;
+                }
+            })
+            .filter(item => {
+                if (!item[this.identifyBy] && !item[this.displayBy]) {
+                    return false;
+                }
+                return true;
+            });
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-chips-4x",
-  "version": "1.7.12",
+  "version": "1.7.13",
   "description": "Tag Input component for Angular",
   "scripts": {
     "release": "npm run build && npm publish dist",


### PR DESCRIPTION
- Supplementary fix for `v1.7.12` handle items with undefined key/value that passed from form.
- Add demonstration for the above case