### PR TITLE
Feature/change display of tag: toggle displaying <identifyBy> value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.7.14 - 2018-08-02
+- Feature: allow user to toggle displaying `<identifyBy>:<displayBy>` format.
+    - By default this is off (display only the value of `<displayBy>`). Add `withCode="true"` to enable this feature.
+- doc: add demonstration for this feature.
+
 ## 1.7.13 - 2018-07-30
 - fix: supplementary fix for [v1.7.12](#1.7.12\ -\ 2018-07-26): handle items with undefined key/value that passed from form.
 - doc: add demonstration for the case items with undefined key/value passed from form.

--- a/demo/home/home.html
+++ b/demo/home/home.html
@@ -189,9 +189,13 @@
 
         <div>
             <h3>Tags within a form group</h3>
+            <div>
+                <label>Toggle displaying format &lt;id&gt;: &lt;value&gt;</label>
+                <input type="checkbox" [(ngModel)]="displayWithCode">
+            </div>
             <form [formGroup]="form">
                 <tag-input
-                    [disable]="true"
+                    [withCode]="displayWithCode"
                     [formControlName]="'chips'"
                     name="items">
                 </tag-input>
@@ -200,8 +204,13 @@
 
         <div>
             <h3>Tags within a form group. Some items have undefined key and/or value</h3>
+            <div>
+                <label>Toggle displaying format &lt;id&gt;: &lt;value&gt;</label>
+                <input type="checkbox" [(ngModel)]="displayWithCode">
+            </div>
             <form [formGroup]="form">
                 <tag-input
+                    [withCode]="displayWithCode"
                     [displayBy]="'name'"
                     [identifyBy]="'id'"
                     [formControlName]="'undefinedItems'"

--- a/demo/home/home.ts
+++ b/demo/home/home.ts
@@ -40,6 +40,8 @@ export class Home {
         });
     }
 
+    displayWithCode = true;
+
     disabled = true;
 
     items = ['Javascript', 'Typescript'];

--- a/modules/components/dropdown/tag-input-dropdown.component.ts
+++ b/modules/components/dropdown/tag-input-dropdown.component.ts
@@ -406,7 +406,11 @@ export class TagInputDropdown {
             return '';
         }
 
-        return `${item[this.identifyBy]} : ${item[this.displayBy]}`;
+        if (this.tagInput.withCode) {
+            return `${item[this.identifyBy]} : ${item[this.displayBy]}`;
+        } else {
+            return item[this.displayBy];
+        }
     }
 
     /**

--- a/modules/components/tag-input/tag-input.template.html
+++ b/modules/components/tag-input/tag-input.template.html
@@ -44,6 +44,7 @@
              [editable]="editable"
              [displayBy]="displayBy"
              [identifyBy]="identifyBy"
+             [withCode]="withCode"
              [template]="!!hasCustomTemplate() ? templates.first : undefined"
              [draggable]="dragZone"
              [model]="item">

--- a/modules/components/tag/tag.component.ts
+++ b/modules/components/tag/tag.component.ts
@@ -65,6 +65,16 @@ export class TagComponent {
     @Input() public identifyBy: string;
 
     /**
+     * Flag to toggle displaying the value of identifyBy or not.
+     * If true, display item as <identifyBy>: <displayBy>
+     * Else display item as <displayBy>
+     *
+     * @type {boolean}
+     * @memberof TagComponent
+     */
+    @Input() public withCode: boolean = false;
+
+    /**
      * @name index {number}
      */
     @Input() public index: number;
@@ -244,10 +254,12 @@ export class TagComponent {
             }
             return '';
         } else {
-            if (!item[this.identifyBy]) {
-                return item[this.displayBy];
+            if (this.withCode) {
+                if (!!item[this.identifyBy]) {
+                    return `${item[this.identifyBy]} : ${item[this.displayBy]}`;
+                }
             }
-            return `${item[this.identifyBy]} : ${item[this.displayBy]}`;
+            return item[this.displayBy];
         }
     }
 
@@ -332,6 +344,7 @@ export class TagComponent {
      * @param input
      */
     private storeNewValue(input: string): void {
+        console.log('aaaaa Tag.storeNewValue', input);
         const exists = (tag: TagModel) => {
             return typeof tag === 'string' ?
             tag === input :

--- a/modules/components/tag/tag.component.ts
+++ b/modules/components/tag/tag.component.ts
@@ -344,7 +344,6 @@ export class TagComponent {
      * @param input
      */
     private storeNewValue(input: string): void {
-        console.log('aaaaa Tag.storeNewValue', input);
         const exists = (tag: TagModel) => {
             return typeof tag === 'string' ?
             tag === input :

--- a/modules/core/accessor.ts
+++ b/modules/core/accessor.ts
@@ -27,6 +27,16 @@ export class TagInputAccessor implements ControlValueAccessor {
      */
     @Input() public identifyBy: string = OptionsProvider.defaults.tagInput.identifyBy;
 
+    /**
+     * Flag to toggle displaying the value of identifyBy or not.
+     * If true, display item as <identifyBy>: <displayBy>
+     * Else display item as <displayBy>
+     *
+     * @type {boolean}
+     * @memberof TagInputAccessor
+     */
+    @Input() public withCode: boolean = OptionsProvider.defaults.tagInput.withCode;
+
     public get items(): TagModel[] {
         return this._items;
     };

--- a/modules/defaults.ts
+++ b/modules/defaults.ts
@@ -38,6 +38,7 @@ export interface TagInputOptions {
     onAdding?: (tag: TagModel) => Observable<TagModel>;
     displayBy: string;
     identifyBy: string;
+    withCode: boolean;
     animationDuration: {
         enter: string,
         leave: string
@@ -91,6 +92,7 @@ export const defaults = {
         onAdding: undefined,
         displayBy: 'display',
         identifyBy: 'value',
+        withCode: false,
         animationDuration: {
             enter: '250ms',
             leave: '150ms'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-chips-4x",
-  "version": "1.7.13",
+  "version": "1.7.14",
   "description": "Tag Input component for Angular",
   "scripts": {
     "release": "npm run build && npm publish dist",


### PR DESCRIPTION
- Feature: allow user to toggle displaying `<identifyBy>:<displayBy>` format.
    - By default this is off (display only the value of `<displayBy>`). Add `withCode="true"` to enable this feature.
- doc: add demonstration for this feature.